### PR TITLE
:bug: Badly formatted message

### DIFF
--- a/mediator-app/src/main/java/net/wasdev/gameon/mediator/PlayerConnectionMediator.java
+++ b/mediator-app/src/main/java/net/wasdev/gameon/mediator/PlayerConnectionMediator.java
@@ -115,7 +115,7 @@ public class PlayerConnectionMediator {
      */
     public static final String CLIENT_ACK = "ack";
 
-    public static final String FINDROOM_FAIL = "{\"type\": \"event\",\"content\": \"Oh dear. That door led nowhere. \",\"bookmark\": 0}";
+    public static final String FINDROOM_FAIL = "{\"type\": \"event\",\"content\": {\"*\": \"Oh dear. That door led nowhere. \"},\"bookmark\": 0}";
     public static final String CONNECTING = "{\"type\": \"joinpart\",\"content\": \"...connecting to %s...\",\"bookmark\": 0}";
     public static final String FINDROOM = "{\"type\": \"joinpart\",\"content\": \"...finding the next room...\",\"bookmark\": 0}";
     public static final String PART = "{\"type\": \"joinpart\",\"content\": \"exit %s\",\"bookmark\": 0}";


### PR DESCRIPTION
```
parse message: "{"type": "event","content": "Oh dear. That door led nowhere. ","bookmark": 0}" Object
```

Bad format in the event prevented this message from being displayed (which made an abandoned room transition look like a hang instead).
