### PR TITLE
Move jwt to headers

### DIFF
--- a/mediator-app/src/main/java/net/wasdev/gameon/mediator/PlayerClient.java
+++ b/mediator-app/src/main/java/net/wasdev/gameon/mediator/PlayerClient.java
@@ -32,12 +32,11 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.ResponseProcessingException;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 
 /**
  * A wrapped/encapsulation of outbound REST requests to the player service.
@@ -168,16 +167,17 @@ public class PlayerClient {
      * @return
      */
     public String getSharedSecret(String playerId, String jwt) {
-        WebTarget target = this.root.path("{playerId}").resolveTemplate("playerId", playerId).queryParam("jwt",
-                jwt);
-
+        WebTarget target = this.root.path("{playerId}").resolveTemplate("playerId", playerId);
+        
         Log.log(Level.FINER, this, "requesting shared secret using {0}", target.getUri().toString());
 
         try {
             // Make PUT request using the specified target, get result as a
             // string containing JSON
-            String result = target.request(MediaType.APPLICATION_JSON)//.accept(MediaType.APPLICATION_JSON)
-                    .header("Content-type", "application/json").get(String.class);
+            Invocation.Builder builder = target.request(MediaType.APPLICATION_JSON);
+            builder.header("Content-type", "application/json");
+            builder.header("gameon-jwt", jwt);
+            String result = builder.get(String.class);
 
             JsonReader p = Json.createReader(new StringReader(result));
             JsonObject j = p.readObject();

--- a/mediator-app/src/main/java/net/wasdev/gameon/mediator/PlayerConnectionManager.java
+++ b/mediator-app/src/main/java/net/wasdev/gameon/mediator/PlayerConnectionManager.java
@@ -39,7 +39,6 @@ import javax.json.JsonObject;
 import javax.websocket.Session;
 
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import net.wasdev.gameon.mediator.auth.JWT;
@@ -221,33 +220,15 @@ public class PlayerConnectionManager implements Runnable {
             // mediator that doesn't,
             // ends here..
 
-            if (signingKey == null)
+            if (signingKey == null) {
                 getKeyStoreInfo();
+            }
+                
             
             // get the jwt from the message
             String token = message.getOptionalValue("jwt", null);
             JWT jwt = new JWT(signingKey, token);
-            
-            /*
-            String query = clientSession.getQueryString();
-            String params[] = query.split("&");
-            String jwtParam = null;
-            for (String param : params) {
-                if (param.startsWith("jwt=")) {
-                    jwtParam = param.substring("jwt=".length());
-                }
-            }
-
-            // grab the key if needed
-            if (signingKey == null)
-                getKeyStoreInfo();
-
-            // parse the jwt into an object..
-            Jws<Claims> jwt = Jwts.parser().setSigningKey(signingKey).parseClaimsJws(jwtParam);
-
-            // create a new jwt with type server for use by this session.
-             */
-            
+                        
             Claims onwardsClaims = Jwts.claims();
             // add all the client claims
             onwardsClaims.putAll(jwt.getClaims());

--- a/mediator-app/src/main/java/net/wasdev/gameon/mediator/PlayerConnectionManager.java
+++ b/mediator-app/src/main/java/net/wasdev/gameon/mediator/PlayerConnectionManager.java
@@ -224,10 +224,22 @@ public class PlayerConnectionManager implements Runnable {
                 getKeyStoreInfo();
             }
                 
+         // get the jwt from the ws query url.
+            String jwtParam = null;
+            String query = clientSession.getQueryString();
+            if((query != null) && !query.isEmpty()) {
+                String params[] = query.split("&");
+                for (String param : params) {
+                    if (param.startsWith("jwt=")) {
+                        jwtParam = param.substring("jwt=".length());
+                    }
+                }
+            }
             
             // get the jwt from the message
             String token = message.getOptionalValue("jwt", null);
-            JWT jwt = new JWT(signingKey, token);
+            
+            JWT jwt = new JWT(signingKey, token, jwtParam);
                         
             Claims onwardsClaims = Jwts.claims();
             // add all the client claims

--- a/mediator-app/src/main/java/net/wasdev/gameon/mediator/PlayerConnectionManager.java
+++ b/mediator-app/src/main/java/net/wasdev/gameon/mediator/PlayerConnectionManager.java
@@ -42,6 +42,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import net.wasdev.gameon.mediator.auth.JWT;
 
 /**
  * Lifecycle management for mediators. When a "ready" message is received, the
@@ -220,7 +221,14 @@ public class PlayerConnectionManager implements Runnable {
             // mediator that doesn't,
             // ends here..
 
-            // get the jwt from the ws query url.
+            if (signingKey == null)
+                getKeyStoreInfo();
+            
+            // get the jwt from the message
+            String token = message.getOptionalValue("jwt", null);
+            JWT jwt = new JWT(signingKey, token);
+            
+            /*
             String query = clientSession.getQueryString();
             String params[] = query.split("&");
             String jwtParam = null;
@@ -238,9 +246,11 @@ public class PlayerConnectionManager implements Runnable {
             Jws<Claims> jwt = Jwts.parser().setSigningKey(signingKey).parseClaimsJws(jwtParam);
 
             // create a new jwt with type server for use by this session.
+             */
+            
             Claims onwardsClaims = Jwts.claims();
             // add all the client claims
-            onwardsClaims.putAll(jwt.getBody());
+            onwardsClaims.putAll(jwt.getClaims());
             // upgrade the type to server
             onwardsClaims.setAudience("server");
 

--- a/mediator-app/src/main/java/net/wasdev/gameon/mediator/PlayerServerEndpoint.java
+++ b/mediator-app/src/main/java/net/wasdev/gameon/mediator/PlayerServerEndpoint.java
@@ -55,6 +55,7 @@ public class PlayerServerEndpoint {
      */
     @OnOpen
     public void onOpen(@PathParam("userId") String userId, Session session, EndpointConfig ec) {
+        System.out.println("Connection from user : " + userId);
         Log.log(Level.FINER, session, "client open - {0}", userId, session, session.getQueryString(), session.getUserProperties());
     }
 

--- a/mediator-app/src/main/java/net/wasdev/gameon/mediator/PlayerServerEndpoint.java
+++ b/mediator-app/src/main/java/net/wasdev/gameon/mediator/PlayerServerEndpoint.java
@@ -55,7 +55,6 @@ public class PlayerServerEndpoint {
      */
     @OnOpen
     public void onOpen(@PathParam("userId") String userId, Session session, EndpointConfig ec) {
-        System.out.println("Connection from user : " + userId);
         Log.log(Level.FINER, session, "client open - {0}", userId, session, session.getQueryString(), session.getUserProperties());
     }
 

--- a/mediator-app/src/main/java/net/wasdev/gameon/mediator/auth/JWT.java
+++ b/mediator-app/src/main/java/net/wasdev/gameon/mediator/auth/JWT.java
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ * Copyright (c) 2016 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package net.wasdev.gameon.mediator.auth;
+
+import java.security.Key;
+import java.security.cert.Certificate;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+
+/**
+ * Common class for handling JSON Web Tokens
+ * 
+ * @author marknsweep
+ *
+ */
+
+public class JWT {
+    private final AuthenticationState state;
+    private FailureCode code;
+    private String token = null;
+    private Jws<Claims> jwt = null;
+
+    public JWT(Certificate cert, String... sources) {
+        state = processSources(cert.getPublicKey(), sources);
+    }
+    
+    public JWT(Key key, String... sources) {
+        state = processSources(key, sources);
+    }
+    
+    // the authentication steps that are performed on an incoming request
+    public enum AuthenticationState {
+        UNKNOWN,                        // starting state
+        hasJWTParam, hasJWTHeader, isJWTValid, 
+        PASSED, ACCESS_DENIED           // end state
+    }
+    
+    public enum FailureCode {
+        NONE,
+        BAD_SIGNATURE,
+        EXPIRED
+    }
+    
+    private enum ProcessState {
+        FIND_SOURCE,
+        VALIDATE,
+        COMPLETE
+    }
+    
+    private AuthenticationState processSources(Key key, String[] sources) {
+        AuthenticationState state = AuthenticationState.ACCESS_DENIED; // default
+        ProcessState process = ProcessState.FIND_SOURCE;
+        while (!process.equals(ProcessState.COMPLETE)) {
+            switch (process) {
+            case FIND_SOURCE :
+                //find the first non-empty source
+                for(int i = 0; i < sources.length && ((token == null) || token.isEmpty()); token = sources[i++]);
+                process = ((token == null) || token.isEmpty()) ? ProcessState.COMPLETE : ProcessState.VALIDATE;  
+                break;
+            case VALIDATE: // validate the jwt
+                boolean jwtValid = false;
+                try {
+                    jwt = Jwts.parser().setSigningKey(key).parseClaimsJws(token);
+                    jwtValid = true;
+                    code = FailureCode.NONE;
+                } catch (io.jsonwebtoken.SignatureException e) {
+                    // thrown if the signature on id_token cannot be verified.
+                    System.out.println("JWT did NOT validate ok, bad signature.");
+                    code = FailureCode.BAD_SIGNATURE;
+                } catch (ExpiredJwtException e) {
+                    // thrown if the jwt had expired.
+                    System.out.println("JWT did NOT validate ok, jwt had expired");
+                    code = FailureCode.EXPIRED;
+                }
+                state = !jwtValid ? AuthenticationState.ACCESS_DENIED : AuthenticationState.PASSED;
+                process = ProcessState.COMPLETE;
+                break;
+            default:
+                process = ProcessState.COMPLETE;
+                break;
+            }
+        }
+        return state;
+    }
+
+    public AuthenticationState getState() {
+        return state;
+    }
+
+    public FailureCode getCode() {
+        return code;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public Claims getClaims() {
+        return jwt.getBody();
+    }
+    
+    
+}

--- a/mediator-app/src/main/java/net/wasdev/gameon/mediator/auth/JWT.java
+++ b/mediator-app/src/main/java/net/wasdev/gameon/mediator/auth/JWT.java
@@ -17,11 +17,13 @@ package net.wasdev.gameon.mediator.auth;
 
 import java.security.Key;
 import java.security.cert.Certificate;
+import java.util.logging.Level;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
+import net.wasdev.gameon.mediator.Log;
 
 /**
  * Common class for handling JSON Web Tokens
@@ -46,8 +48,6 @@ public class JWT {
     
     // the authentication steps that are performed on an incoming request
     public enum AuthenticationState {
-        UNKNOWN,                        // starting state
-        hasJWTParam, hasJWTHeader, isJWTValid, 
         PASSED, ACCESS_DENIED           // end state
     }
     
@@ -80,12 +80,10 @@ public class JWT {
                     jwtValid = true;
                     code = FailureCode.NONE;
                 } catch (io.jsonwebtoken.SignatureException e) {
-                    // thrown if the signature on id_token cannot be verified.
-                    System.out.println("JWT did NOT validate ok, bad signature.");
+                    Log.log(Level.WARNING, this, "JWT did NOT validate ok, bad signature.");
                     code = FailureCode.BAD_SIGNATURE;
                 } catch (ExpiredJwtException e) {
-                    // thrown if the jwt had expired.
-                    System.out.println("JWT did NOT validate ok, jwt had expired");
+                    Log.log(Level.WARNING, this, "JWT did NOT validate ok, jwt had expired");
                     code = FailureCode.EXPIRED;
                 }
                 state = !jwtValid ? AuthenticationState.ACCESS_DENIED : AuthenticationState.PASSED;


### PR DESCRIPTION
This PR cannot be done in isolation, it needs the corresponding requests in map, player and webapp which are for the move_jwt_to_headers branch.

This request externalises the JWT (so that it can be shared/consistent) and moves any use of the jwt query param to a gameon-org HTTP header.
