### PR TITLE
add a test for mediator..

### DIFF
--- a/mediator-app/build.gradle
+++ b/mediator-app/build.gradle
@@ -3,6 +3,10 @@ apply plugin: 'eclipse-wtp'
 
 sourceCompatibility = 1.8
 
+configurations {
+    jmockit
+    testCompile.extendsFrom jmockit
+}
 
 dependencies {
     providedCompile group:'javax.websocket', name:'javax.websocket-api', version:'1.1'
@@ -18,6 +22,13 @@ dependencies {
     runtime 'org.slf4j:slf4j-jdk14:1.7.13'
     
     compile 'com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.2.2'
+    
+    jmockit 'org.jmockit:jmockit:1.22'
+    testCompile 'junit:junit:4.12'
+}
+
+test {
+   jvmArgs "-javaagent:${configurations.jmockit.singleFile.absolutePath}"
 }
 
 // Set the Eclipse facets to use 3.1 of the Dynamic Web Module which requires Java 1.7 (at least)

--- a/mediator-app/src/test/java/net/wasdev/gameon/mediator/RemoteRoomMediatorTest.java
+++ b/mediator-app/src/test/java/net/wasdev/gameon/mediator/RemoteRoomMediatorTest.java
@@ -1,0 +1,42 @@
+package net.wasdev.gameon.mediator;
+
+import static mockit.Deencapsulation.setField;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import mockit.Expectations;
+import mockit.Mocked;
+import mockit.integration.junit4.JMockit;
+import net.wasdev.gameon.mediator.models.Exit;
+import net.wasdev.gameon.mediator.models.Exits;
+import net.wasdev.gameon.mediator.models.Site;
+
+@RunWith(JMockit.class)
+public class RemoteRoomMediatorTest {
+    
+    @Test
+    public void testGetExits(@Mocked Exit exit, 
+            @Mocked MapClient mapClient, 
+            @Mocked ConnectionUtils connectionUtils,
+            @Mocked Site site,
+            @Mocked Exits exits){
+                
+        new Expectations() {{  
+            exit.getId(); returns("FISH");
+            exit.getConnectionDetails(); 
+            exit.getName();
+            exit.getFullName();
+            mapClient.getSite("FISH"); returns(site);
+            site.getExits(); returns(exits);
+            
+        }};
+        
+        RemoteRoomMediator r = new RemoteRoomMediator(exit, mapClient, connectionUtils);
+        setField(r,"lastCheck",0);
+        Exits e = r.getExits();
+        
+        assertEquals("Exits object as expected",e,exits);
+    }
+}


### PR DESCRIPTION
Adding a test to make it easier to add more tests.. this adds jmockit,
and junit to the gradle test step.

These tests do run ok in eclipse, although if using ibm jdk, you need to
add the -javaagent argument as it will instruct you when you try to run
them for the first time.

Remember to rebuild the eclipse project with gradle eclipse to have
eclipse pull in the new jars to use.

Signed-off-by: Ozzy Osborne ozzy@ca.ibm.com

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/gameontext/gameon-mediator/27)

<!-- Reviewable:end -->
