### PR TITLE
Close all connections; add trace; tweak docker locations

### DIFF
--- a/mediator-app/src/main/java/net/wasdev/gameon/CORSFilter.java
+++ b/mediator-app/src/main/java/net/wasdev/gameon/CORSFilter.java
@@ -23,12 +23,19 @@ import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import javax.servlet.annotation.WebFilter;
 import javax.servlet.http.HttpServletResponse;
 
+@WebFilter(
+        filterName = "corsFilter",
+        urlPatterns = {"/*"}
+        )
 public class CORSFilter implements Filter {
 
+    @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
             throws IOException, ServletException {
+
         HttpServletResponse sresponse = (HttpServletResponse) response;
         sresponse.setHeader("Access-Control-Allow-Origin", "*");
         sresponse.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE");
@@ -37,9 +44,11 @@ public class CORSFilter implements Filter {
         chain.doFilter(request, response);
     }
 
+    @Override
     public void init(FilterConfig filterConfig) {
     }
 
+    @Override
     public void destroy() {
     }
 }

--- a/mediator-app/src/main/java/net/wasdev/gameon/mediator/ConnectionUtils.java
+++ b/mediator-app/src/main/java/net/wasdev/gameon/mediator/ConnectionUtils.java
@@ -264,19 +264,25 @@ public class ConnectionUtils {
             ended.countDown();
         }
 
+
         public void stop() {
             keepGoing = false;
 
             // Interrupt the other thread
-            if (t != null)
+            if (t != null) {
                 t.interrupt();
 
-            // Wait for the interrupted thread to finish
-            try {
-                ended.await(400, TimeUnit.MILLISECONDS);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
+                // Wait for the interrupted thread to finish
+                try {
+                    ended.await(400, TimeUnit.MILLISECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+
+                t = null;
             }
+
+            connectionUtils.tryToClose(targetSession);
         }
     }
 

--- a/mediator-app/src/main/java/net/wasdev/gameon/mediator/PlayerConnectionMediator.java
+++ b/mediator-app/src/main/java/net/wasdev/gameon/mediator/PlayerConnectionMediator.java
@@ -220,8 +220,9 @@ public class PlayerConnectionMediator {
      * Stop draining the client-bound queue
      */
     public void disconnect() {
-        if (drainToClient != null)
+        if (drainToClient != null) {
             drainToClient.stop();
+        }
     }
 
     /**
@@ -231,13 +232,14 @@ public class PlayerConnectionMediator {
         Log.log(Level.FINE, this, "session {0} destroyed", userId);
         // session expired.
         toClient.clear();
+        disconnect();
 
         Log.log(Level.FINER, this,
                 "playerConnectionMediator for {1} unsubscribing from currentRoom {0} and setting it to null",
                 currentRoom.getName(), userId);
 
         currentRoom.unsubscribe(this);
-        currentRoom.disconnect();
+        currentRoom.disconnect(); // make sure the websocket to the server is closed
         currentRoom = null;
     }
 

--- a/mediator-app/src/main/java/net/wasdev/gameon/mediator/RemoteRoomMediator.java
+++ b/mediator-app/src/main/java/net/wasdev/gameon/mediator/RemoteRoomMediator.java
@@ -365,8 +365,9 @@ public class RemoteRoomMediator implements RoomMediator {
     private void connectionClosed(CloseReason reason) {
         Log.log(Level.FINER, this, "ROOM CONNECTION CLOSED {0}: {1}", id, reason);
 
-        if (drainToRoom != null)
+        if (drainToRoom != null) {
             drainToRoom.stop();
+        }
 
         if (playerMediator != null && !reason.getCloseCode().equals(CloseCodes.NORMAL_CLOSURE)) {
             connect();

--- a/mediator-app/src/main/webapp/WEB-INF/web.xml
+++ b/mediator-app/src/main/webapp/WEB-INF/web.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd" version="3.1">
-    <filter>
-         <filter-name>CORS</filter-name>
-         <filter-class>net.wasdev.gameon.CORSFilter</filter-class>
-     </filter>
-     <filter-mapping>
-         <filter-name>CORS</filter-name>
-         <url-pattern>/*</url-pattern>
-     </filter-mapping>
+    <display-name>Game On Mediator</display-name>
+
+    <welcome-file-list>
+        <welcome-file>index.html</welcome-file>
+    </welcome-file-list>
+
  </web-app>

--- a/mediator-wlpcfg/Dockerfile.live
+++ b/mediator-wlpcfg/Dockerfile.live
@@ -5,10 +5,17 @@ MAINTAINER Ben Smith
 ENV SERVERDIRNAME mediator
 
 ADD https://download.elastic.co/logstash-forwarder/binaries/logstash-forwarder_linux_amd64 /opt/forwarder
-ADD ./servers/gameon-mediator /opt/ibm/wlp/usr/servers/$SERVERDIRNAME/
-ADD ./server-logmet-dropin.xml /opt/ibm/wlp/usr/servers/$SERVERDIRNAME/configDropins/overrides/
 
-RUN wget https://github.com/coreos/etcd/releases/download/v2.2.2/etcd-v2.2.2-linux-amd64.tar.gz -q; tar xzf etcd-v2.2.2-linux-amd64.tar.gz etcd-v2.2.2-linux-amd64/etcdctl --strip-components=1; rm etcd-v2.2.2-linux-amd64.tar.gz; mv etcdctl /usr/local/bin/etcdctl
+# Liberty docker files are more accustomed to working with defaultServer
+# Place config files in the usual location (defaultServer), startup.sh will ensure
+# server is started with a unique name for differentiation of log data.
+ADD ./servers/gameon-mediator /opt/ibm/wlp/usr/servers/defaultServer/
+ADD ./server-logmet-dropin.xml /opt/ibm/wlp/usr/servers/defaultServer/configDropins/overrides/
+
+RUN wget https://github.com/coreos/etcd/releases/download/v2.2.2/etcd-v2.2.2-linux-amd64.tar.gz -q; \
+    tar xzf etcd-v2.2.2-linux-amd64.tar.gz etcd-v2.2.2-linux-amd64/etcdctl --strip-components=1; \
+    rm etcd-v2.2.2-linux-amd64.tar.gz; \
+    mv etcdctl /usr/local/bin/etcdctl
 
 COPY ./forwarder.conf /opt/forwarder.conf
 

--- a/mediator-wlpcfg/servers/gameon-mediator/server.xml
+++ b/mediator-wlpcfg/servers/gameon-mediator/server.xml
@@ -31,10 +31,10 @@
 
   <jndiEntry jndiName="mapUrl" value="${env.MAP_URL}"/>
   <jndiEntry jndiName="mapApiKey" value="${env.MAP_KEY}"/>
-  
+
   <jndiEntry jndiName="systemId" value="${env.SYSTEM_ID}"/>
 
-  <logging consoleLogLevel="INFO" traceSpecification="*=info:net.wasdev.gameon.*=all"/>
+  <logging consoleLogLevel="INFO" traceSpecification="*=info:net.wasdev.gameon.*=all:TCPChannel=fine:websockets=all"/>
 
   <applicationMonitor dropinsEnabled="false"/>
   <webApplication contextRoot="/mediator" id="mediator-app" location="mediator-app.war" name="mediator-app"/>

--- a/mediator-wlpcfg/startup.sh
+++ b/mediator-wlpcfg/startup.sh
@@ -2,6 +2,13 @@
 
 if [ "$SERVERDIRNAME" == "" ]; then
   SERVERDIRNAME=defaultServer
+else
+  # Share the configuration directory via symlink
+  ln -s /opt/ibm/wlp/usr/servers/defaultServer /opt/ibm/wlp/usr/servers/$SERVERDIRNAME
+
+  # move the convenience output dir link to the new output location
+  rm /output
+  ln -s $WLP_OUTPUT_DIR/$SERVERDIRNAME /output
 fi
 
 if [ "$ETCDCTL_ENDPOINT" != "" ]; then
@@ -19,7 +26,7 @@ if [ "$ETCDCTL_ENDPOINT" != "" ]; then
       RC=$?
   done
   echo "etcdctl returned sucessfully, continuing"
- 
+
   mkdir -p /opt/ibm/wlp/usr/servers/$SERVERDIRNAME/resources/security
   cd /opt/ibm/wlp/usr/servers/$SERVERDIRNAME/resources/
   etcdctl get /proxy/third-party-ssl-cert > cert.pem
@@ -38,7 +45,7 @@ if [ "$ETCDCTL_ENDPOINT" != "" ]; then
   export LOGMET_TENANT=$(etcdctl get /logmet/tenant)
   export LOGMET_PWD=$(etcdctl get /logmet/pwd)
   export SYSTEM_ID=$(etcdctl get /player/system_id)
-  
+
   # Softlayer needs a logstash endpoint so we set up the server
   # to run in the background and the primary task is running the
   # forwarder. In ICS, Liberty is the primary task so we need to


### PR DESCRIPTION
We have a memory or connection leak somewhere.

This tweaks the connection/session management a bit to try to ensure connections are closed, and adds some trace so we can make sure of that (will have to watch the trace when running live, but.. )

Also publishing files to defaultServer, as that is where the base websphere dockerfile expects it. We'll use the mediator server name at runtime to allow differentiation of log data.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameontext/gameon-mediator/30)

<!-- Reviewable:end -->
