### PR TITLE
Add owner info to teleport response and long id to listmyrooms response

### DIFF
--- a/mediator-app/src/main/java/net/wasdev/gameon/mediator/room/FirstRoom.java
+++ b/mediator-app/src/main/java/net/wasdev/gameon/mediator/room/FirstRoom.java
@@ -288,7 +288,7 @@ public class FirstRoom implements RoomMediator {
             roomSummary.append("You have registered the following rooms... \n");
             for (Site room : rooms) {
                 if (room.getInfo() != null) {
-                    roomSummary.append(" - '" + room.getInfo().getFullName() + "' with id " + room.getInfo().getName() + "\n");
+                    roomSummary.append(" - '" + room.getInfo().getFullName() + "' with id " + room.getInfo().getName() + " (long id: " + room.getId() +")\n");
                 }
             }
             roomSummary.append("\nYou can go directly to your own rooms using /teleport <roomid>");
@@ -362,9 +362,9 @@ public class FirstRoom implements RoomMediator {
             return null;
         }
         if (possibleCandidates.size() > 1) {
-            StringBuilder returnedMessage = new StringBuilder("There are multiple rooms with the same ID. To get to the correct room, use one of the following long IDs (you may need to ask the room owner which ID is for their room):\n");
+            StringBuilder returnedMessage = new StringBuilder("There are multiple rooms with the same ID. To get to the correct room, use one of the following long IDs:\n");
             for (Site site : possibleCandidates) {
-                returnedMessage.append(" - /teleport "+site.getId()+"\n");
+                returnedMessage.append(" - /teleport "+site.getId()+ " (owned by " + site.getOwner() + ")\n");
             }
             responseBuilder.add(RoomUtils.TYPE, RoomUtils.EVENT).add(RoomUtils.CONTENT,
                     RoomUtils.buildContentResponse(

--- a/mediator-app/src/main/java/net/wasdev/gameon/mediator/room/FirstRoom.java
+++ b/mediator-app/src/main/java/net/wasdev/gameon/mediator/room/FirstRoom.java
@@ -291,7 +291,7 @@ public class FirstRoom implements RoomMediator {
                     roomSummary.append(" - '" + room.getInfo().getFullName() + "' with id " + room.getInfo().getName() + " (long id: " + room.getId() +")\n");
                 }
             }
-            roomSummary.append("\nYou can go directly to your own rooms using /teleport <roomid>");
+            roomSummary.append("\nYou can go directly to a room using /teleport <roomid>");
         } else {
             roomSummary.append("You have no rooms registered!");
         }

--- a/mediator-app/src/test/java/net/wasdev/gameon/mediator/ListMyRoomsTest.java
+++ b/mediator-app/src/test/java/net/wasdev/gameon/mediator/ListMyRoomsTest.java
@@ -101,7 +101,7 @@ public class ListMyRoomsTest {
                 "You have registered the following rooms... \n"
                 + " - '" + singleReturnedRoom.getInfo().getFullName() + "' with id "
                 + singleReturnedRoom.getInfo().getName() + " (long id: " + singleReturnedRoom.getId() +")\n"
-                + "\nYou can go directly to your own rooms using /teleport <roomid>");
+                + "\nYou can go directly to a room using /teleport <roomid>");
     }
 
     @Test
@@ -149,7 +149,7 @@ public class ListMyRoomsTest {
                 + room1.getInfo().getName() + " (long id: " + room1.getId() +")\n"
                 + " - '" + room2.getInfo().getFullName() + "' with id "
                 + room2.getInfo().getName() + " (long id: " + room2.getId() +")\n"
-                + "\nYou can go directly to your own rooms using /teleport <roomid>");
+                + "\nYou can go directly to a room using /teleport <roomid>");
 
     }
 

--- a/mediator-app/src/test/java/net/wasdev/gameon/mediator/ListMyRoomsTest.java
+++ b/mediator-app/src/test/java/net/wasdev/gameon/mediator/ListMyRoomsTest.java
@@ -33,14 +33,15 @@ import mockit.Expectations;
 import mockit.Mocked;
 import mockit.integration.junit4.JMockit;
 import net.wasdev.gameon.mediator.mocks.MockedPlayerSession;
+import net.wasdev.gameon.mediator.models.RoomInfo;
 import net.wasdev.gameon.mediator.models.Site;
 import net.wasdev.gameon.mediator.room.FirstRoom;
 
 @RunWith(JMockit.class)
-public class TeleportTest {
+public class ListMyRoomsTest {
 
     @Test
-    public void testTeleportNoRooms(@Mocked MapClient mapClient) {
+    public void testNoRooms(@Mocked MapClient mapClient) {
         PlayerClient playerClient = new PlayerClient();
         String playerJwt = "testUser";
 
@@ -51,24 +52,60 @@ public class TeleportTest {
                 playerSession.getLastClientMessage());
 
         RoutedMessage routedMessage = RoutedMessage.createMessage("room", "firstRoom",
-                "{\"username\":\"DevUser\",\"userId\":\"dummy.DevUser\",\"content\":\"/teleport steve\"}");
+                "{\"username\":\"DevUser\",\"userId\":\"testUser\",\"content\":\"/listmyrooms\"}");
 
         new Expectations() {{
-            mapClient.getSite("steve"); returns(null);
-            mapClient.getRoomsByRoomName("steve"); returns(Collections.emptyList());
+            mapClient.getRoomsByOwner(playerJwt); returns(Collections.emptyList());
         }};
 
         firstRoom.send(routedMessage);
         RoutedMessage lastClientMessage = playerSession.getLastClientMessage();
 
-        checkMessageHeaders(lastClientMessage, "player", "dummy.DevUser", "event");
+        checkMessageHeaders(lastClientMessage, "player", "testUser", "event");
 
+        checkMessageContentAsObject(lastClientMessage, "You have no rooms registered!");
+    }
+
+    @Test
+    public void testOneRoom(@Mocked MapClient mapClient) {
+        PlayerClient playerClient = new PlayerClient();
+        String playerJwt = "testUser";
+
+        FirstRoom firstRoom = new FirstRoom(playerJwt, playerClient, mapClient);
+        MockedPlayerSession playerSession = new MockedPlayerSession();
+        assertTrue("The subscription should be successful", firstRoom.subscribe(playerSession, 0));
+        assertNull("A subscription for a non-newbie should not trigger a message",
+                playerSession.getLastClientMessage());
+
+        RoutedMessage routedMessage = RoutedMessage.createMessage("room", "firstRoom",
+                "{\"username\":\"DevUser\",\"userId\":\"testUser\",\"content\":\"/listmyrooms\"}");
+
+        List<Site> returnedSites = new ArrayList<Site>();
+        Site singleReturnedRoom = new Site();
+        singleReturnedRoom.setId("steve");
+        RoomInfo roomInfo = new RoomInfo();
+        roomInfo.setFullName("AnotherRoomForSteve");
+        roomInfo.setName("stevesRoom");
+        singleReturnedRoom.setInfo(roomInfo);
+        returnedSites.add(singleReturnedRoom);
+
+        new Expectations() {{
+            mapClient.getRoomsByOwner(playerJwt); returns(returnedSites);
+        }};
+
+        firstRoom.send(routedMessage);
+        RoutedMessage lastClientMessage = playerSession.getLastClientMessage();
+
+        checkMessageHeaders(lastClientMessage, "player", playerJwt, "event");
         checkMessageContentAsObject(lastClientMessage,
-                "You don't appear to have a room with that id to teleport to.. maybe you should check `/listmyrooms`");
+                "You have registered the following rooms... \n"
+                + " - '" + singleReturnedRoom.getInfo().getFullName() + "' with id "
+                + singleReturnedRoom.getInfo().getName() + " (long id: " + singleReturnedRoom.getId() +")\n"
+                + "\nYou can go directly to your own rooms using /teleport <roomid>");
     }
 
     @Test
-    public void testTeleportOneRoom(@Mocked MapClient mapClient) {
+    public void testTwoRooms(@Mocked MapClient mapClient) {
         PlayerClient playerClient = new PlayerClient();
         String playerJwt = "testUser";
 
@@ -79,96 +116,40 @@ public class TeleportTest {
                 playerSession.getLastClientMessage());
 
         RoutedMessage routedMessage = RoutedMessage.createMessage("room", "firstRoom",
-                "{\"username\":\"DevUser\",\"userId\":\"dummy.DevUser\",\"content\":\"/teleport steve\"}");
-
-        List<Site> returnedSites = new ArrayList<Site>();
-        Site singleReturnedRoom = new Site();
-        singleReturnedRoom.setId("steve");
-        returnedSites.add(singleReturnedRoom);
-
-        new Expectations() {{
-            mapClient.getSite("steve"); returns(null);
-            mapClient.getRoomsByRoomName("steve");
-            returns(returnedSites);
-        }};
-
-        firstRoom.send(routedMessage);
-        RoutedMessage lastClientMessage = playerSession.getLastClientMessage();
-
-        checkMessageHeaders(lastClientMessage, "playerLocation", "dummy.DevUser", "exit");
-        checkMessageContentAsString(lastClientMessage,
-                "You punch the coordinates into the console, a large tube appears from above you, and you are sucked into a maze of piping.");
-
-    }
-    
-    @Test
-    public void testTeleportById(@Mocked MapClient mapClient) {
-        PlayerClient playerClient = new PlayerClient();
-        String playerJwt = "testUser";
-
-        FirstRoom firstRoom = new FirstRoom(playerJwt, playerClient, mapClient);
-        MockedPlayerSession playerSession = new MockedPlayerSession();
-        assertTrue("The subscription should be successful", firstRoom.subscribe(playerSession, 0));
-        assertNull("A subscription for a non-newbie should not trigger a message",
-                playerSession.getLastClientMessage());
-
-        RoutedMessage routedMessage = RoutedMessage.createMessage("room", "firstRoom",
-                "{\"username\":\"DevUser\",\"userId\":\"dummy.DevUser\",\"content\":\"/teleport steve\"}");
-
-        List<Site> returnedSites = new ArrayList<Site>();
-        Site singleReturnedRoom = new Site();
-        singleReturnedRoom.setId("steve");
-        returnedSites.add(singleReturnedRoom);
-
-        new Expectations() {{
-            mapClient.getSite("steve"); returns(singleReturnedRoom);
-        }};
-
-        firstRoom.send(routedMessage);
-        RoutedMessage lastClientMessage = playerSession.getLastClientMessage();
-
-        checkMessageHeaders(lastClientMessage, "playerLocation", "dummy.DevUser", "exit");
-        checkMessageContentAsString(lastClientMessage,
-                "You punch the coordinates into the console, a large tube appears from above you, and you are sucked into a maze of piping.");
-
-    }
-
-    @Test
-    public void testTeleportTwoRooms(@Mocked MapClient mapClient) {
-        PlayerClient playerClient = new PlayerClient();
-        String playerJwt = "testUser";
-
-        FirstRoom firstRoom = new FirstRoom(playerJwt, playerClient, mapClient);
-        MockedPlayerSession playerSession = new MockedPlayerSession();
-        assertTrue("The subscription should be successful", firstRoom.subscribe(playerSession, 0));
-        assertNull("A subscription for a non-newbie should not trigger a message",
-                playerSession.getLastClientMessage());
-
-        RoutedMessage routedMessage = RoutedMessage.createMessage("room", "firstRoom",
-                "{\"username\":\"DevUser\",\"userId\":\"dummy.DevUser\",\"content\":\"/teleport steve\"}");
+                "{\"username\":\"DevUser\",\"userId\":\"testUser\",\"content\":\"/listmyrooms\"}");
 
         List<Site> returnedSites = new ArrayList<Site>();
         Site room1 = new Site();
         room1.setId("siteIdForRoom1");
-        room1.setOwner("user1");
+        RoomInfo roomInfo1 = new RoomInfo();
+        roomInfo1.setFullName("site1FullName");
+        roomInfo1.setName("site1");
+        room1.setInfo(roomInfo1);
         returnedSites.add(room1);
+        
         Site room2 = new Site();
         room2.setId("siteIdForRoom2");
-        room2.setOwner("user2");
+        RoomInfo roomInfo2 = new RoomInfo();
+        roomInfo2.setFullName("site1FullName");
+        roomInfo2.setName("site1");
+        room2.setInfo(roomInfo2);
         returnedSites.add(room2);
 
         new Expectations() {{
-            mapClient.getSite("steve"); returns(null);
-            mapClient.getRoomsByRoomName("steve");
-            returns(returnedSites);
+            mapClient.getRoomsByOwner(playerJwt); returns(returnedSites);
         }};
 
         firstRoom.send(routedMessage);
         RoutedMessage lastClientMessage = playerSession.getLastClientMessage();
 
-        checkMessageHeaders(lastClientMessage, "player", "dummy.DevUser", "event");
+        checkMessageHeaders(lastClientMessage, "player", "testUser", "event");
         checkMessageContentAsObject(lastClientMessage,
-                "/teleport siteIdForRoom1 (owned by user1)\n - /teleport siteIdForRoom2 (owned by user2)\n");
+                "You have registered the following rooms... \n"
+                + " - '" + room1.getInfo().getFullName() + "' with id "
+                + room1.getInfo().getName() + " (long id: " + room1.getId() +")\n"
+                + " - '" + room2.getInfo().getFullName() + "' with id "
+                + room2.getInfo().getName() + " (long id: " + room2.getId() +")\n"
+                + "\nYou can go directly to your own rooms using /teleport <roomid>");
 
     }
 
@@ -186,15 +167,6 @@ public class TeleportTest {
 
     }
 
-    private void checkMessageContentAsString(RoutedMessage messageToCheck, String expectedContent) {
-        JsonObject actualMessageBody = messageToCheck.getParsedBody();
-        assertNotNull("There should be a message body in the returned message", actualMessageBody);
-        String actualContent = actualMessageBody.getString("content");
-        assertNotNull("There should be content in the message body", actualContent);
-        assertTrue("The message to should contain [" + expectedContent + "], but got [" + actualContent + "]",
-                actualContent.contains(expectedContent));
-    }
-
     private void checkMessageContentAsObject(RoutedMessage messageToCheck, String expectedMessageToAll) {
         JsonObject actualMessageBody = messageToCheck.getParsedBody();
         assertNotNull("There should be a message body in the returned message", actualMessageBody);
@@ -207,3 +179,4 @@ public class TeleportTest {
     }
 
 }
+


### PR DESCRIPTION
Add owner information to response from teleport when multiple rooms have same id. Add long id information to response from listmyrooms.

Signed-off-by: Katherine Stanley katheris@uk.ibm.com

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameontext/gameon-mediator/36)

<!-- Reviewable:end -->
