### PR TITLE
Update teleport

### DIFF
--- a/mediator-app/src/main/java/org/gameontext/mediator/ClientMediator.java
+++ b/mediator-app/src/main/java/org/gameontext/mediator/ClientMediator.java
@@ -165,8 +165,8 @@ public class ClientMediator implements UserView {
                 if (roomMediator.getType() == Type.FIRST_ROOM) {
                     teleport = message.getBoolean(FirstRoom.TELEPORT, false);
                 }else{
-                    // Not first room, but requesting teleport?
-                    if (message.getBoolean(FirstRoom.TELEPORT,false)) {
+                    // Not first room, but requesting teleport to non-null destination?
+                    if (exitId != null && message.getBoolean(FirstRoom.TELEPORT,false) ) {
                         // If the destination room has the same owner as the current room, allow teleport.
                         String srcOwnerId = roomMediator.getOwnerId();
                         String dstOwnerId = mapClient.getOwnerId(exitId);

--- a/mediator-app/src/main/java/org/gameontext/mediator/ClientMediator.java
+++ b/mediator-app/src/main/java/org/gameontext/mediator/ClientMediator.java
@@ -56,11 +56,17 @@ public class ClientMediator implements UserView {
     /** The mediator for the connected room */
     private volatile RoomMediator roomMediator = null;
 
-    public ClientMediator(MediatorNexus nexus, Drain drain, String userId, String signedJwt) {
+    /**
+     * Client to query map service for room owners during teleport tests.
+     */
+    private MapClient mapClient;
+
+    public ClientMediator(MediatorNexus nexus, Drain drain, String userId, String signedJwt, MapClient client) {
         this.nexus = nexus;
         this.userId = userId;
         this.toClient = drain;
         this.signedJwt = signedJwt;
+        this.mapClient = client;
 
         toClient.start();
     }
@@ -158,6 +164,14 @@ public class ClientMediator implements UserView {
                 // (moving to a room directly without looking up an exit)
                 if (roomMediator.getType() == Type.FIRST_ROOM) {
                     teleport = message.getBoolean(FirstRoom.TELEPORT, false);
+                }else{
+                    // Not first room, but requesting teleport?
+                    if (message.getBoolean(FirstRoom.TELEPORT,false)) {
+                        // If the destination room has the same owner as the current room, allow teleport.
+                        String srcOwnerId = roomMediator.getOwnerId();
+                        String dstOwnerId = mapClient.getOwnerId(exitId);
+                        teleport = srcOwnerId.equals(dstOwnerId);
+                    }
                 }
 
                 if (teleport) {

--- a/mediator-app/src/main/java/org/gameontext/mediator/MapClient.java
+++ b/mediator-app/src/main/java/org/gameontext/mediator/MapClient.java
@@ -162,6 +162,19 @@ public class MapClient {
     }
 
     /**
+     * Obtain owner id for a given roomID.
+     * @return ownerId if site is found, null otherwise.
+     */
+    public String getOwnerId(String roomId){
+        Site site = getSite(roomId);
+        if(site==null){
+            return null;
+        }else{
+            return site.getOwner();
+        }
+    }
+
+    /**
      * Construct an outbound {@code WebTarget} that builds on the root
      * {@code WebTarget#path(String)} to add the path segment required to
      * request the Site for a given room (<code>{roomId}</code>).

--- a/mediator-app/src/main/java/org/gameontext/mediator/MediatorBuilder.java
+++ b/mediator-app/src/main/java/org/gameontext/mediator/MediatorBuilder.java
@@ -71,7 +71,7 @@ public class MediatorBuilder {
 
     @Resource
     ManagedScheduledExecutorService scheduledExecutor;
-      
+
     @Resource(lookup = "systemId")
     String SYSTEM_ID;
 
@@ -98,7 +98,7 @@ public class MediatorBuilder {
             drain.send(RoutedMessage.PING_MSG);
         }, 50, 2, TimeUnit.SECONDS));
 
-        ClientMediator clientMediator = new ClientMediator(nexus, drain, userId, serverJwt);
+        ClientMediator clientMediator = new ClientMediator(nexus, drain, userId, serverJwt, mapClient);
         return clientMediator;
     }
 
@@ -270,7 +270,7 @@ public class MediatorBuilder {
         String roomId = site.getId();
         WSDrain drain = new WSDrain(roomId);
         drain.setThread(threadFactory.newThread(drain));
-        
+
         String reason = null;
 
         try {
@@ -291,7 +291,7 @@ public class MediatorBuilder {
         } catch(Exception e) {
             Log.log(Level.FINEST, this, "tryRemoteDelegate FAILED: proxy={0}, userId={1}, exception={2}",
                     Log.getHexHash(proxy), user, e);
-            
+
             reason = Instant.now().toString()+" "+e.getMessage();
         }
 


### PR DESCRIPTION
Ok, so we still don't have suites.. but here's an idea that might tide us over =)

If the source and destination room have the same ownerId, allow teleport between them. 

Then rooms could override /go direction into /teleport target-room-id allowing creation of intentional room graphs overlaid over the existing navigable map. Done correctly a room could test if a player is 'playing' or not, so that when players enter from 'outside' the connected-room graph by stumbling into a room on the main graph, they can bounce them to the start room.. For extra credit rooms could remember where a player entered their connected-room graphs, and have them exit back to that location when they quit.. so many options!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameontext/gameon-mediator/88)
<!-- Reviewable:end -->
