### PR TITLE
Persist and move without kafka

### DIFF
--- a/mediator-app/src/main/java/org/gameontext/mediator/MapClient.java
+++ b/mediator-app/src/main/java/org/gameontext/mediator/MapClient.java
@@ -65,9 +65,9 @@ public class MapClient {
     String mapLocation;
 
     /**
-     * The concierge API key injected from JNDI via CDI.
+     * The map API key injected from JNDI via CDI.
      *
-     * @see {@code conciergeQueryApiKey} in
+     * @see {@code mapApiKey} in
      *      {@code /mediator-wlpcfg/servers/gameon-mediator/server.xml}
      */
     @Resource(lookup = "mapApiKey")

--- a/mediator-app/src/test/java/org/gameontext/mediator/MediatorNexusTest.java
+++ b/mediator-app/src/test/java/org/gameontext/mediator/MediatorNexusTest.java
@@ -580,6 +580,8 @@ public class MediatorNexusTest {
             room2.getFullName(); result = roomFullName;
             room2.listExits(); result = roomExits;
 
+            playerClient.updatePlayerLocation("client1",(String)any,roomId,roomId2); result = roomId2;
+
             builder.findMediatorForRoom((ClientMediatorPod) any, roomId); result = room1;
             builder.findMediatorForRoom((ClientMediatorPod) any, roomId2); result = room2;
         }};
@@ -654,17 +656,7 @@ public class MediatorNexusTest {
 
         // CHEATING: call nested inner directly
         // private synchronized void transition(ClientMediator playerSession, String fromRoomId, String targetRoomId, boolean updatePlayerLocation) 
-        try {
-            transition.invoke(pod, client1, "otherRoom", Constants.FIRST_ROOM, false);
-            Assert.fail("Expected concurrent modification exception");
-        } catch(InvocationTargetException e) {
-            if ( ! (e.getCause() instanceof ConcurrentModificationException) ) {
-                throw e.getCause();
-            }
-            // Yay!
-        } catch(ConcurrentModificationException ex) {
-            //YAY!!
-        }
+        transition.invoke(pod, client1, "otherRoom", Constants.FIRST_ROOM, false);
 
         new Verifications() {{
             UserView join;
@@ -699,6 +691,8 @@ public class MediatorNexusTest {
             room2.getName(); result = roomName;
             room2.getFullName(); result = roomFullName;
             room2.listExits(); result = roomExits;
+
+            playerClient.updatePlayerLocation("client1",(String)any,Constants.FIRST_ROOM,roomId); result = roomId;
 
             builder.findMediatorForRoom((ClientMediatorPod) any, Constants.FIRST_ROOM); result = room1;
             builder.findMediatorForExit((ClientMediatorPod) any, room1, "N"); result = room2;
@@ -860,17 +854,7 @@ public class MediatorNexusTest {
 
         // CHEATING: call nested inner directly
         // private synchronized void transitionViaExit(ClientMediator playerSession, String fromRoomId, String direction)
-        try {
-            transitionViaExit.invoke(pod, client1, "otherRoom", "N");
-            Assert.fail("Expected concurrent modification exception");
-        } catch(InvocationTargetException e) {
-            if ( ! (e.getCause() instanceof ConcurrentModificationException) ) {
-                throw e.getCause();
-            }
-            // YAY!
-        } catch(ConcurrentModificationException ex) {
-            //YAY!!
-        }
+        transitionViaExit.invoke(pod, client1, "otherRoom", "N");
 
         new Verifications() {{
             UserView join;

--- a/mediator-wlpcfg/Dockerfile
+++ b/mediator-wlpcfg/Dockerfile
@@ -1,9 +1,9 @@
-FROM gameontext/docker-liberty-custom:master-9
+FROM gameontext/docker-liberty-custom:master-12
 
 ENV SERVERDIRNAME mediator
 
 COPY ./startup.sh /opt/startup.sh
-ADD ./servers/gameon-mediator /opt/ol/wlp/usr/servers/defaultServer/
+COPY ./servers/gameon-mediator /opt/ol/wlp/usr/servers/defaultServer/
 
 CMD ["/opt/startup.sh"]
 

--- a/mediator-wlpcfg/servers/gameon-mediator/server.xml
+++ b/mediator-wlpcfg/servers/gameon-mediator/server.xml
@@ -25,6 +25,8 @@
     </accessLogging>
   </httpEndpoint>
 
+  <jndiEntry jndiName="serverUuid" value="${wlp.server.uuid}" />
+
   <!-- Signed JWT keystore info -->
   <jndiEntry jndiName="jwtKeyStore" value="${server.config.dir}/resources/security/key.jks"/>
   <jndiEntry jndiName="jwtKeyStorePassword" value="testOnlyKeystore"/>

--- a/mediator-wlpcfg/startup.sh
+++ b/mediator-wlpcfg/startup.sh
@@ -48,8 +48,6 @@ if [ "$ETCDCTL_ENDPOINT" != "" ]; then
   #from github, and have to use an extra config snippet to enable it.
   export MESSAGEHUB_USER=$(etcdctl get /kafka/user)
   export MESSAGEHUB_PASSWORD=$(etcdctl get /passwords/kafka)
-  cd ${SERVER_PATH}
-  wget https://github.com/ibm-messaging/message-hub-samples/raw/master/kafka-0.9/message-hub-login-library/messagehub.login-1.0.0.jar
 fi
 
 if [ -f /etc/cert/cert.pem ]; then
@@ -59,7 +57,7 @@ if [ -f /etc/cert/cert.pem ]; then
   echo "-cd dir"
   cd ${SERVER_PATH}/resources/
   echo "-importing jvm truststore to server truststore"
-  keytool -importkeystore -srckeystore $JAVA_HOME/lib/security/cacerts -destkeystore security/truststore.jks -srcstorepass changeit -deststorepass truststore  
+  keytool -importkeystore -srckeystore $JAVA_HOME/lib/security/cacerts -destkeystore security/truststore.jks -srcstorepass changeit -deststorepass truststore
   echo "-converting pem to pkcs12"
   openssl pkcs12 -passin pass:keystore -passout pass:keystore -export -out cert.pkcs12 -in /etc/cert/cert.pem
   echo "-importing pem to truststore.jks"


### PR DESCRIPTION
Use the response from the player service to move the player between rooms (compensating
if there were conflicts). Send the service's UUID to player when requesting the
location update, so that location changes caused by this mediator can be ignored
(only relevant while the instance is running, otherwise meaningless data).

Signed-off-by: Erin Schnabel <schnabel@us.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameontext/gameon-mediator/90)
<!-- Reviewable:end -->
